### PR TITLE
Add sass and integrate with tailwind and dummy app

### DIFF
--- a/app/styles/tailwind-purgecss-addon/_common.scss
+++ b/app/styles/tailwind-purgecss-addon/_common.scss
@@ -1,0 +1,9 @@
+/*! purgecss start ignore */
+@tailwind base;
+@tailwind components;
+/*! purgecss stop ignore */
+@tailwind utilities;
+
+@import "variables";
+@import "mixins";
+@import "components/some-component";

--- a/app/styles/tailwind-purgecss-addon/_mixins.scss
+++ b/app/styles/tailwind-purgecss-addon/_mixins.scss
@@ -1,0 +1,3 @@
+@mixin some-padding {
+  @apply p-4;
+}

--- a/app/styles/tailwind-purgecss-addon/_variables.scss
+++ b/app/styles/tailwind-purgecss-addon/_variables.scss
@@ -1,0 +1,4 @@
+$purple: #675882;
+$blue: #0f8ec7;
+$aqua: #6fc8cb;
+$green: #3eb66f;

--- a/app/styles/tailwind-purgecss-addon/components/_some-component.scss
+++ b/app/styles/tailwind-purgecss-addon/components/_some-component.scss
@@ -1,0 +1,5 @@
+.some-component {
+  background: $blue;
+  @apply text-green;
+  @include some-padding;
+}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -31,7 +31,18 @@ module.exports = function(defaults) {
   let app = new EmberAddon(defaults, {
     postcssOptions: {
       compile: {
+        extension: 'scss',
+        enabled: true,
+        parser: require('postcss-scss'),
         plugins: [
+          {
+            module: require('@csstools/postcss-sass'),
+            options: {
+              includePaths: [
+                'node_modules',
+              ],
+            },
+          },
           require('tailwindcss')('./tests/dummy/config/tailwind.config.js'),
           ...[purgeCSS],
         ]

--- a/package.json
+++ b/package.json
@@ -27,10 +27,13 @@
     "ember-cli-htmlbars": "^5.1.2"
   },
   "peerDependencies": {
+    "@csstools/postcss-sass": "^4.0.0",
     "ember-cli-postcss": "^6.0.1",
+    "postcss-scss": "^2.1.1",
     "tailwindcss": "^1.5.1"
   },
   "devDependencies": {
+    "@csstools/postcss-sass": "^4.0.0",
     "@ember/optional-features": "^1.3.0",
     "@fullhuman/postcss-purgecss": "^2.3.0",
     "@glimmer/component": "^1.0.0",
@@ -59,6 +62,7 @@
     "eslint-plugin-node": "^11.1.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
+    "postcss-scss": "^2.1.1",
     "qunit-dom": "^1.2.0",
     "tailwindcss": "^1.5.1"
   },

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,5 +1,0 @@
-/*! purgecss start ignore */
- @tailwind base;
- @tailwind components;
-/*! purgecss stop ignore */
- @tailwind utilities;

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -1,0 +1,1 @@
+@import "tailwind-purgecss-addon/common";

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,4 +2,8 @@
   <h2 id="title" class="text-2xl">Welcome to Ember</h2>
 
   {{outlet}}
+
+  <p class="some-component">
+    More lorem ipsum.
+  </p>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,6 +869,21 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@csstools/postcss-sass@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/postcss-sass/-/postcss-sass-4.0.0.tgz#6617c5096a6b71751ee0b87d2326418b9d97effb"
+  integrity sha512-yvm2aaODNJ8PBn43HjYiRvVJcYLEpz5BEKXxQ/7HryqcL+TnAceXZO+khadTEkjw90r8afR5wykTzvVpFeo4vw==
+  dependencies:
+    "@csstools/sass-import-resolve" "^1.0.0"
+    postcss "^7.0.14"
+    sass "^1.16.1"
+    source-map "~0.7.3"
+
+"@csstools/sass-import-resolve@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@csstools/sass-import-resolve/-/sass-import-resolve-1.0.0.tgz#32c3cdb2f7af3cd8f0dca357b592e7271f3831b5"
+  integrity sha512-pH4KCsbtBLLe7eqUrw8brcuFO8IZlN36JjdKlOublibVdAIPHCzEnpBWOVUXK5sCf+DpBi8ZtuWtjF0srybdeA==
+
 "@ember-data/rfc395-data@^0.0.4":
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/@ember-data/rfc395-data/-/rfc395-data-0.0.4.tgz#ecb86efdf5d7733a76ff14ea651a1b0ed1f8a843"
@@ -3453,6 +3468,21 @@ charm@^1.0.0:
   dependencies:
     inherits "^2.0.1"
 
+"chokidar@>=2.0.0 <4.0.0", chokidar@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.1.tgz#e905bdecf10eaa0a0b1db0c664481cc4cbc22ba1"
+  integrity sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.4.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
@@ -3471,21 +3501,6 @@ chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
-
-chokidar@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.1.tgz#e905bdecf10eaa0a0b1db0c664481cc4cbc22ba1"
-  integrity sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==
-  dependencies:
-    anymatch "~3.1.1"
-    braces "~3.0.2"
-    glob-parent "~5.1.0"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.4.0"
-  optionalDependencies:
-    fsevents "~2.1.2"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -8661,6 +8676,13 @@ postcss-nested@^4.1.1:
     postcss "^7.0.32"
     postcss-selector-parser "^6.0.2"
 
+postcss-scss@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-2.1.1.tgz#ec3a75fa29a55e016b90bf3269026c53c1d2b383"
+  integrity sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==
+  dependencies:
+    postcss "^7.0.6"
+
 postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
@@ -8680,7 +8702,7 @@ postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@7.0.32, postcss@^7.0.0, postcss@^7.0.11, postcss@^7.0.18, postcss@^7.0.32, postcss@^7.0.5:
+postcss@7.0.32, postcss@^7.0.0, postcss@^7.0.11, postcss@^7.0.14, postcss@^7.0.18, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
   version "7.0.32"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
   integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
@@ -9466,6 +9488,13 @@ sane@^4.0.0, sane@^4.1.0:
     minimist "^1.1.1"
     walker "~1.0.5"
 
+sass@^1.16.1:
+  version "1.26.10"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.26.10.tgz#851d126021cdc93decbf201d1eca2a20ee434760"
+  integrity sha512-bzN0uvmzfsTvjz0qwccN1sPm2HxxpNI/Xa+7PlUEMS+nQvbyuEK7Y0qFqxlPHhiNHb1Ze8WQJtU31olMObkAMw==
+  dependencies:
+    chokidar ">=2.0.0 <4.0.0"
+
 saxes@^3.1.3:
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/saxes/-/saxes-3.1.11.tgz#d59d1fd332ec92ad98a2e0b2ee644702384b1c5b"
@@ -9851,6 +9880,11 @@ source-map@~0.1.x:
   integrity sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@~0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 sourcemap-validator@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Part of https://github.com/intercom/intercom/issues/180255

Adds tailwind and postcss as a dependency to an addon. The addon exposes a `tailwind-purgecss-addon/common` file which is imported into the main app's stylesheet.

![image](https://user-images.githubusercontent.com/685034/87959229-7c7c6680-caaa-11ea-8402-9b9aba5ff5d5.png)
